### PR TITLE
Solve clash of TFT and buzzer libraries

### DIFF
--- a/Badge2020_TFT.h
+++ b/Badge2020_TFT.h
@@ -6,7 +6,7 @@
 #include <SPI.h>
 
 #define BADGE2020_TFT_CS          5
-#define BADGE2020_TFT_RST        32
+#define BADGE2020_TFT_RST        26
 #define BADGE2020_TFT_DC         33
 #define BADGE2020_BACKLIGHT      12
 


### PR DESCRIPTION
The TFT's reset pin is not connected to any GPIO.  However, the TFT library requires a RST pin to be set.  The current TFT library had IO32 set as reset pin.  However, this pin is used for the buzzer.  Hence, the buzzer stopped working if the TFT library is loaded as well.

This is solved by setting the reset pin to IO26 which is not connected to anything on the board (though it is still broken out on the microbit connector).