### PR TITLE
Verwijder define BADGE2020_BACKLIGHT

### DIFF
--- a/Badge2020_TFT.h
+++ b/Badge2020_TFT.h
@@ -8,7 +8,6 @@
 #define BADGE2020_TFT_CS          5
 #define BADGE2020_TFT_RST        26
 #define BADGE2020_TFT_DC         33
-#define BADGE2020_BACKLIGHT      12
 
 class Badge2020_TFT : public Adafruit_ST7789 {
 public:

--- a/examples/1.Basics/tftscreen/tftscreen.ino
+++ b/examples/1.Basics/tftscreen/tftscreen.ino
@@ -6,9 +6,6 @@ void setup(void) {
   tft.init(240, 240);
   tft.setRotation( 2 );
 
-  pinMode( BADGE2020_BACKLIGHT, OUTPUT );
-  digitalWrite( BADGE2020_BACKLIGHT, HIGH );
-
   // Anything from the Adafruit GFX library can go here, see
   // https://learn.adafruit.com/adafruit-gfx-graphics-library
   

--- a/examples/2.Demos/clock/clock.ino
+++ b/examples/2.Demos/clock/clock.ino
@@ -30,8 +30,6 @@ void setup(void) {
 
   tft.init(240, 240);
   tft.setRotation(2);
-  pinMode(BADGE2020_BACKLIGHT, OUTPUT);
-  digitalWrite(BADGE2020_BACKLIGHT, HIGH);
   tft.fillScreen(ST77XX_BLACK);
   tft.setCursor(10, 10);
   tft.setTextColor(ST77XX_WHITE);

--- a/examples/2.Demos/gameon_tester/gameon_tester.ino
+++ b/examples/2.Demos/gameon_tester/gameon_tester.ino
@@ -18,9 +18,6 @@ void setup(void)
   tft.init(240, 240);
   tft.setRotation(2);
 
-  pinMode(BADGE2020_BACKLIGHT, OUTPUT);
-  digitalWrite(BADGE2020_BACKLIGHT, HIGH);
-
   pinMode(GAMEON_UP, INPUT_PULLUP);
   pinMode(GAMEON_DOWN, INPUT_PULLUP);
   pinMode(GAMEON_LEFT, INPUT_PULLUP);

--- a/examples/2.Demos/googly_eye/googly_eye.ino
+++ b/examples/2.Demos/googly_eye/googly_eye.ino
@@ -11,9 +11,6 @@ void setup(void) {
   tft.init(240, 240);
   tft.setRotation( 2 );
 
-  pinMode( BADGE2020_BACKLIGHT, OUTPUT );
-  digitalWrite( BADGE2020_BACKLIGHT, HIGH );
-
   tft.fillScreen( 0x2c45 );
   tft.fillCircle( 120, 120, 100, ST77XX_WHITE );
 


### PR DESCRIPTION
Blijkbaar bestond in een prototype versie een backlight pin waarmee via software de display backlight aan/uit kon gezet worden. In de finale versie kan dit niet meer, dus kan dit beter uit de software verwijderd worden om verwarring te vermijden.