### PR TITLE
TFT Reset pin fix

### DIFF
--- a/Badge2020_TFT.h
+++ b/Badge2020_TFT.h
@@ -6,7 +6,7 @@
 #include <SPI.h>
 
 #define BADGE2020_TFT_CS          5
-#define BADGE2020_TFT_RST        26
+#define BADGE2020_TFT_RST        -1
 #define BADGE2020_TFT_DC         33
 
 class Badge2020_TFT : public Adafruit_ST7789 {


### PR DESCRIPTION
Voor zover ik begrijp, is de TFT reset pin niet verbonden met een GPIO, maar in de code wordt verwezen naar pin 26, die ook overeenkomt met left op GameOn. Dat kan dus potentieel tot problemen leiden. Beter lijkt me de pin als -1 te definiëren, zoals de Adafruit documentatie beschrijft.