### PR TITLE
Add methods to enable and disable the TFT backlight

### DIFF
--- a/Badge2020_TFT.cpp
+++ b/Badge2020_TFT.cpp
@@ -1,1 +1,24 @@
 #include <Badge2020_TFT.h>
+#include <Wire.h>
+
+Badge2020_TFT::Badge2020_TFT() : Adafruit_ST7789( BADGE2020_TFT_CS, BADGE2020_TFT_DC, BADGE2020_TFT_RST )
+{
+  // open Wire connection to talk to accelerometer
+  Wire.begin();
+}
+
+void Badge2020_TFT::enableBacklight()
+{
+  Wire.beginTransmission(BADGE2020_ACC_ADDRESS);
+  Wire.write(BADGE2020_ACC_CTRL_REG5);
+  Wire.write(0x0A);  // enable INT2; pulling IO36 HIGH
+  Wire.endTransmission(true);
+}
+
+void Badge2020_TFT::disableBacklight()
+{
+  Wire.beginTransmission(BADGE2020_ACC_ADDRESS);
+  Wire.write(BADGE2020_ACC_CTRL_REG5);
+  Wire.write(0x00);  // disable INT2; pulling IO36 LOW
+  Wire.endTransmission(true);
+}

--- a/Badge2020_TFT.h
+++ b/Badge2020_TFT.h
@@ -9,10 +9,17 @@
 #define BADGE2020_TFT_RST        -1
 #define BADGE2020_TFT_DC         33
 
+#define BADGE2020_ACC_ADDRESS    0x18
+#define BADGE2020_ACC_CTRL_REG5  0x25
+
 class Badge2020_TFT : public Adafruit_ST7789 {
 public:
-	Badge2020_TFT() : Adafruit_ST7789( BADGE2020_TFT_CS, BADGE2020_TFT_DC, BADGE2020_TFT_RST ) {}
-private:  
+	Badge2020_TFT();
+
+	// NOTE: these methods only work if the backlight switch is set to AUTO
+	void enableBacklight();
+	void disableBacklight();  // NOTE: this will also disable the select button of the game-on
+private:
 
 };
 	


### PR DESCRIPTION
Note that this will only work if the backlight switch is set to AUTO.
Note also that the select button on the game-on will not work if the
backlight is disabled.

The way this is implemented is by using a trick.  The backlight LED is
not directly connected to any pin of the ESP32, but it is connected to
the interrupt pins of the accelerometer.  The level of IO36 can
therefore be manipulated by enabling/disabling the interrupt
functionality on the accelerometer, which will pull the line HIGH or
LOW.